### PR TITLE
Add `publishConfig` to `package.json`

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -14,6 +14,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@performant-software'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
   },
   "devDependencies": {
     "http-server": "^14.1.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
This should fix the issue where NPM assumes we want to publish a private package just because we're using a scope.