### PR TITLE
Add ability to include glossary via a `link` TEI element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "editioncrafter-cli",
+  "name": "@performant-software/editioncrafter-cli",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "editioncrafter-cli",
+      "name": "@performant-software/editioncrafter-cli",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "jsdom": "^21.1.0"
       },
       "bin": {
-        "editioncrafter-cli": "src/index.js"
+        "editioncrafter": "editioncrafter"
       },
       "devDependencies": {
         "http-server": "^14.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@performant-software/editioncrafter-cli",
-  "version": "0.0.1",
+  "name": "@cu-mkp/editioncrafter-cli",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@performant-software/editioncrafter-cli",
-      "version": "0.0.1",
+      "name": "@cu-mkp/editioncrafter-cli",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "jsdom": "^21.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@performant-software/editioncrafter-cli",
-  "version": "0.0.1",
+  "name": "@cu-mkp/editioncrafter-cli",
+  "version": "0.0.3",
   "description": "This is the command line tool to take a TEI XML file and turn it into a IIIF Manifest and the necessary Web Annotations to display the text in EditionCrafter.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
# Summary

- updates the `process` script to look for a `link` element of `type` "glossary"
  - if found, that link will be included in a `seeAlso` object in the IIIF manifest

# Examples

## Input

```xml
<link type="glossary" target="http://localhost:6006/fr640_3r-3v-example/glossary.json" />
```

## Output

```json
	"seeAlso": [
		{
			"id": "http://localhost:6006/fr640_3r-3v-example/glossary.json",
			"type": "Dataset",
			"label": "Glossary",
			"format": "text/json"
		}
	]
```