### PR TITLE
Add `structuredClone` polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@ungap/structured-clone": "^1.2.0",
         "axios": "^1.4.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -29,6 +30,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/abab": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "node_modules/.bin/http-server --cors"
   },
   "dependencies": {
+    "@ungap/structured-clone": "^1.2.0",
     "axios": "^1.4.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/src/render.js
+++ b/src/render.js
@@ -7,6 +7,8 @@ const canvasTemplate = require("./templates/canvas.json")
 const annotationTemplate = require("./templates/annotation.json")
 const annotationPageTemplate = require("./templates/annotationPage.json")
 
+const structuredClone = require('@ungap/structured-clone').default
+
 // Profile ID for EditionCrafter text partials
 const textPartialResourceProfileID = 'https://github.com/cu-mkp/editioncrafter-project/text-partial-resource.md'
 


### PR DESCRIPTION
This PR addresses #17 by using a polyfill for the `structuredClone` function. This allows us to reduce the minimum Node version below 18.

@NickLaiacona While the output looks good to me after this change, you might be better at noticing any subtle problems that might come up, so I decided to request a review/test from you instead of pushing straight to `dev`.