### PR TITLE
Adds `iiif` command functionality and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,7 @@ The `editioncrafter` command will now be available. If it doesn't work right awa
 
 ## Usage
 
-Usage: `editioncrafter <command> [-c config_path]|[<tei_path> <output_path> <base_url>]`
-
-Edition Crafter responds to the following `<command>`s:
-* process: Process the TEI Document into a manifest, partials, and annotations.
-* server: Run in server mode (WIP)
-* help: Displays this help.
-
-The optional configuration file is a JSON file with the following options:
+The following commands are available to the EditionCrafter CLI. Note that you may optionally pass the path of a configuration file as `-c config_path` rather than passing individual parameters. The optional configuration file is a JSON file with the following options:
 
 ```
 {
@@ -46,6 +39,31 @@ The optional configuration file is a JSON file with the following options:
     "thumbnailHeight": 192
 }
 ```
+
+### help
+
+Usage:
+```
+editioncrafter help
+```
+This will display information on the syntax for passing commands to the CLI as well as a list of available commands.
+
+### iiif 
+
+Usage:
+```
+editioncrafter iiif <iiif_url> <output_path>
+```
+This will create an XML file at the location of the provided `<output_path>` based on the information in the IIIF manifest supplied. Note that in this case the `<output_path>` should be a single XML File, e.g. `/MyFiles/TEI/index.xml`.
+
+### process
+
+Usage:
+```
+editioncrafter process <tei_file> <output_path> <base_url>
+```
+This will create all of the artifacts that EditionCrafter needs in order to display your document on the web, and place them in the specified `<output_path>` folder. The `<base_url>` parameter should be the URL at which you intend to host these artifacts.
+
 
 ## Generates the following files:
 

--- a/src/iiif.js
+++ b/src/iiif.js
@@ -1,0 +1,12 @@
+
+
+function processIIIF(options) {
+    const { iiifURL, targetPath } = options
+
+    
+
+
+}
+
+
+module.exports.processIIIF = processIIIF;

--- a/src/iiif.js
+++ b/src/iiif.js
@@ -1,11 +1,432 @@
+const fs = require('fs');
+const axios = require('axios');
 
+
+//THIS IS WHERE WE CREATE THE ACTUAL TEI DOCUMENT STRING FROM THE FACSIMILE JSON DATA
+
+function facsTemplate(facsData) { 
+    const { manifestID, surfaces } = facsData
+
+    const surfaceEls = []
+    for( const surface of surfaces ) {
+        const { id, type, width, height, imageAPIURL, canvasURI, localLabels, mimeType, resourceEntryID, zones  } = surface
+        const labelEls = renderLocalLabels(localLabels)
+        const zoneEls = zones ? renderZones(zones) : ""
+        
+        if( type === 'iiif' ) {
+            surfaceEls.push(
+                `<surface xml:id="${id}" ulx="0" uly="0" lrx="${width}" lry="${height}" sameAs="${canvasURI}" >${labelEls}<graphic mimeType="application/json" url="${imageAPIURL}"/>${zoneEls}</surface>`
+            )    
+        } else {
+            const ext = getExtensionForMIMEType(mimeType)
+            const filename = `${id}.${ext}`
+            surfaceEls.push(
+                `<surface xml:id="${id}" ulx="0" uly="0" lrx="${width}" lry="${height}">${labelEls}<graphic sameAs="${resourceEntryID}" mimeType="${mimeType}" url="${filename}"/>${zoneEls}</surface>`
+            )    
+        }
+    }
+
+    const sameAs = (manifestID) ? `sameAs="${manifestID}"` : ''
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>
+                    <!-- Your Title Here -->
+                </title>
+            </titleStmt>
+            <publicationStmt>
+                <p></p>
+            </publicationStmt>
+            <sourceDesc>
+                <p></p>
+            </sourceDesc>
+        </fileDesc>
+    </teiHeader>
+            
+    <facsimile ${sameAs}>
+        ${surfaceEls.join('')}
+    </facsimile>
+    
+    <text xml:id="transcription">
+        <body>
+            <p>Modify xml:id as desired and replace this with your text.</p>
+        </body>
+    </text>
+</TEI>`
+};
+
+//FUNCTION TO GET THE IIIF DATA FROM THE PROVIDED URL AND PASS IT TO THE APPROPRIATE PARSERS
+
+function importPresentationEndpoint(manifestURL, onSuccess, nextSurfaceID = 0) {
+    axios.get(manifestURL).then(
+        (resp) => {
+            try {
+                const iiifTree = parseIIIFPresentation(resp.data, nextSurfaceID)
+                onSuccess(iiifTree)
+            } catch(error) {
+                throw new Error(`Unable to parse IIIF manifest: '${error}`)      
+            }
+        },
+        (error) => {
+            throw new Error(`Unable to load IIIF manifest.`)
+        }
+    );
+};
+
+//THESE FIVE FUNCTIONS TAKE IN THE MANIFEST DATA AND RETURN A JSON OBJECT WITH THE FACSIMILE DATA
+
+function parseIIIFPresentation( presentation, nextSurfaceID ) {
+    const context = presentation["@context"]
+    if( context.includes("http://iiif.io/api/presentation/2/context.json") ) {
+        return parsePresentation2( presentation, nextSurfaceID )
+    } else if( context.includes("http://iiif.io/api/presentation/3/context.json") ) {
+        return parsePresentation3( presentation, nextSurfaceID )
+    }
+    throw new Error("Expected IIIF Presentation API context 2.")
+};
+
+function parsePresentation2( presentation, nextSurfaceID ) {
+    if( presentation['@type'] === "sc:Manifest") {
+        return manifestToFacsimile2(presentation,nextSurfaceID)
+    } else {
+        throw new Error("Only Manifests are supported.")
+    }    
+};
+
+function parsePresentation3( presentation, nextSurfaceID ) {
+    if( presentation.type === "Manifest") {
+        return manifestToFacsimile3(presentation,nextSurfaceID)
+    } else {
+        throw new Error("Only Manifests are supported for Presentation API v3")
+    }    
+};
+
+function manifestToFacsimile3( manifestData, nextSurfaceID ) {
+    if( manifestData.type !== "Manifest" ) throw new Error("Expected a manifest as the root object.")
+    
+    const canvases = manifestData.items
+    const manifestID = val('id', manifestData)
+    const manifestLabel = str( manifestData.label )
+    
+    const surfaceIDs = []
+    const surfaces = []
+    let n=nextSurfaceID
+    for( const canvas of canvases ) {
+        if( canvas.type !== "Canvas" ) throw new Error("Expected a Canvas item.")
+        const canvasURI = canvas.id
+    const annotationPage = canvas.items[0]
+    const {width: canvasWidth, height: canvasHeight} = canvas
+    if( !annotationPage || annotationPage.type !== "AnnotationPage" ) throw new Error("Expected an Annotation Page item.")
+    const annotations = annotationPage.items
+for( const annotation of annotations ) {
+            if( annotation.type !== "Annotation" ) throw new Error("Expected an Annotation item.")
+            if( annotation.motivation === "painting" && annotation.body && annotation.body.type === "Image" ) {
+                const {body} = annotation
+                // width and height might be on Annotation or the Canvas
+                const width = isNaN(body.width) ? canvasWidth : body.width
+                const height = isNaN(body.height) ? canvasHeight : body.height
+                
+                let imageAPIURL
+                if( body.service ) {
+                    for( const serving of body.service ) {
+                        const servingType = val('type', serving)
+                        if( servingType === "ImageService2" || servingType === "ImageService3") {
+                            imageAPIURL = val('id', serving)
+                            break
+                        }
+                    }
+                } else {
+                    imageAPIURL = val('id', body)
+                }
+                let localLabels = str( canvas.label )
+                let id = generateOrdinalID('f',n)
+                localLabels = !localLabels ? { 'none': [ id ] } : localLabels
+                surfaceIDs.push(id)
+                n++ // page count
+                
+                surfaces.push({
+                    id,
+                    type: 'iiif',
+                    localLabels,
+                    width,
+                    height,
+                    imageAPIURL,
+                    zones: [],
+                    texts: [],
+                    canvasURI
+                })  
+                break // one surface per canvas      
+            }
+        } 
+    }
+
+    const { name, requestedID } = parseMetadata(manifestID,manifestLabel)
+
+    return { 
+        id: requestedID,
+        name,
+        type: 'facs',
+        manifestID,
+        texts: [],
+        surfaces
+    }
+};
+
+function manifestToFacsimile2( manifestData, nextSurfaceID ) {
+    const { sequences } = manifestData
+    const manifestID = val('id', manifestData)
+    const manifestLabel = str( manifestData.label )
+    
+    const sequence = sequences[0]
+    const { canvases } = sequence
+    
+    const texts = sequence.rendering ? gatherRenderings2( sequence.rendering ) : []
+    
+    const surfaceIDs = []
+    const surfaces = []
+    let n=nextSurfaceID
+    for( const canvas of canvases ) {
+        const { images, width, height } = canvas
+        const canvasURI = val('id', canvas)
+        const image = images[0]
+        const { resource } = image
+        const imageAPIURL = resource.service ? val('id', resource.service) : val('id', resource)
+        const localLabels = str( canvas.label )
+        let id = generateOrdinalID('f',n)
+        const texts = canvas.seeAlso ? parseSeeAlso2(canvas.seeAlso) : []
+        surfaceIDs.push(id)
+        n++ // page count
+        
+        surfaces.push({
+            id,
+            type: 'iiif',
+            localLabels,
+            width,
+            height,
+            imageAPIURL,
+            zones: [],
+            texts,
+            canvasURI
+        })
+    }
+    const { name, requestedID } = parseMetadata(manifestID,manifestLabel)
+    
+    return { 
+        id: requestedID,
+        name,
+        type: 'facs',
+        manifestID,
+        texts,
+        surfaces    
+    }
+};
+
+//MAIN FUNCTION -- GETS DATA FROM URL, PASSES IT TO THE PARSER FUNCTIONS, THEN CONVERTS TO A TEI STRING AND WRITES TO THE TARGET PATH
 
 function processIIIF(options) {
     const { iiifURL, targetPath } = options
+    const onSuccess = (data) => {
+         const teiString = facsTemplate(data);
+         fs.writeFileSync(targetPath, teiString);
+    }
+    importPresentationEndpoint(iiifURL, onSuccess);
+};
 
+
+// VARIOUS HELPER FUNCTIONS
+
+const JSONLDKeywords = ['id', 'type', 'none']
+
+function renderLocalLabels(localLabels) {
+    const langKeys = Object.keys(localLabels)
+
+    const labelEls = []
+    for( const langKey of langKeys ) {
+        const labels = localLabels[langKey]
+        for( const label of labels ) {
+            if( langKey === 'none' ) {
+                labelEls.push(`<label>${label}</label>`)
+            } else {
+                labelEls.push(`<label xml:lang="${langKey}">${label}</label>`)
+            }
+        }
+    }
     
+    return labelEls.join('')
+}
+
+function renderZones(zones) {
+    const zoneEls = []
+    for( const zone of zones ) {
+        const { id,ulx,uly,lrx,lry,note} = zone
+        const noteEl = note && note.length > 0 ? `<note>${note}</note>` : ""
+        const coordAttrs = zone.points ? `points="${zone.points}"` : `ulx="${ulx}" uly="${uly}" lrx="${lrx}" lry="${lry}"`
+        const zoneEl = `<zone xml:id="${id}" ${coordAttrs}>${noteEl}</zone>`
+        zoneEls.push(zoneEl)
+    }
+    return zoneEls.join('\n')
+}
+
+function str(values) {
+    // IIIF v2 doesn't have localized values, convert it to IIIF v3 format
+    if( typeof values === 'string' ) {
+        return { 'none': [ values ] }
+    } else {
+        return values
+    }
+}
+
+// JSON-LD keywords in IIIF v3 do not have @ symbols
+function val( key, obj ) {
+    if( JSONLDKeywords.includes(key) ) {
+        const atKey = `@${key}`
+        if( obj[atKey] ) {
+            return obj[atKey]
+        } else if( obj[key] ) {
+            return obj[key]
+        } else {
+            return undefined
+        }    
+    } else {
+        return obj[key]
+    }
+}
 
 
+
+function getExtensionForMIMEType( mimeType ) {
+    switch(mimeType) {
+        case 'image/png':
+            return 'png'
+        case 'image/jpeg':
+            return 'jpg'
+        case 'image/gif':
+            return 'gif' 
+        default:
+            throw new Error(`Unknown MIMEType: ${mimeType}`)
+    }        
+}
+
+function generateOrdinalID( prefix, ordinalID ) {
+    let zeros = ""
+
+    if( ordinalID < 10 ) {
+        zeros = zeros + "0"
+    }
+
+    if( ordinalID < 100 ) {
+        zeros = zeros + "0"
+    }
+
+    return `${prefix}${zeros}${ordinalID}`
+}
+
+function gatherRenderings2( rendering ) {
+    const texts = []
+
+    // add texts that are in a recognized format to list of texts
+    function parseRendering( rend ) {
+        if( rend['@id'] && rend['label'] ) {
+            let format = parseFormat(rend)
+            if( format ) {
+                texts.push({
+                    manifestID: rend['@id'],
+                    name: rend['label'],
+                    format
+                })    
+            }
+        }
+    }
+
+    // gather up any tei or plain text renderings and return an array of text refs 
+    if( Array.isArray(rendering) ) {
+        for( const rend of rendering ) {
+            parseRendering(rend)
+        }
+    } else {
+        parseRendering(rendering)
+    }   
+
+    return texts
+}
+
+function parseSeeAlso2(seeAlso) {
+    if( !Array.isArray(seeAlso) ) return []
+    const texts = []
+
+    for( const rend of seeAlso ) {
+        if( rend['@id'] && rend['label'] ) {
+            const format = parseFormat(rend)
+            if( format ) {    
+                texts.push({
+                    manifestID: rend['@id'],
+                    name: rend['label'],
+                    format
+                })
+            }    
+        }
+    }
+
+    return texts
+}
+
+function parseFormat( rend ) {
+    let format = rend['format'] === 'text/plain' ? 'text' : rend['format'] === 'application/tei+xml' ? 'tei' : null
+
+    if( !format && rend['profile'] === fromThePageTEIXML ) {
+        format = 'tei'
+    }
+    return format
+}
+
+function getLocalString( values, lang ) {
+    const langKeys = Object.keys(values)
+
+    // No values provided
+    if( langKeys.length === 0 ) return []
+
+    // If all of the values are associated with the none key, the client must display all of those values.
+    if( langKeys.includes('none') && langKeys.length === 1) {
+        return values['none']
+    }
+    // If any of the values have a language associated with them, the client must display all of the values associated with the language that best matches the language preference.
+    if( values[lang] ) {
+        return values[lang]
+    } 
+    if( !langKeys.includes('none') ) {
+        // If all of the values have a language associated with them, and none match the language preference, the client must select a language and display all of the values associated with that language.
+        return values['en'] ? values['en'] : values[langKeys[0]]
+    } else {
+        // If some of the values have a language associated with them, but none match the language preference, the client must display all of the values that do not have a language associated with them.
+        return values['none']
+    }
+}
+
+function sanitizeID(value) {
+    // can not contain whitespace or any of: '#,&,?,:,/'
+    let cleanID = value.replace(/[\s#&?:/]/g,'');
+    if( cleanID.match(/^[0-9]/) ) {
+        // can't have number as first char
+        cleanID = `_${cleanID}`
+    }
+    return cleanID.length > 0 ? cleanID : null
+}
+
+function parseMetadata(manifestID,manifestLabel) {
+    const name = getLocalString( manifestLabel, 'en' ).join(' ')
+
+    // take the pathname and convert it to a valid local ID
+    const url = new URL(manifestID)
+    const cleanID = sanitizeID(url.pathname)
+    const requestedID = cleanID ? cleanID : `import_${Date.now()}`
+
+    return {
+        name,
+        requestedID
+    }
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 
 const { renderTEIDocument } = require("./render")
 const { serializeTEIDocument } = require("./serialize")
-const { runServer } = require("./server.js")
+const { processIIIF } = require("./iiif")
 
 // For paths provided by the user
 function processUserPath(input_path) {
@@ -25,8 +25,8 @@ function processTEIDocument(options) {
 async function run(options) {
     if( options.mode === 'process' ) {
         processTEIDocument(options)
-    } else if( options.mode === 'server' ) {
-        runServer(options)
+    } else if( options.mode === 'iiif' ) {
+        processIIIF(options)
     }
 }
 
@@ -77,17 +77,17 @@ function processArguments() {
         if( args[5+argumentOffset] ) config.baseURL = args[5+argumentOffset] 
         config.teiDocumentID = getResourceIDFromPath(config.targetPath)
         return config
-    } else if( mode === 'server' ) {
-        console.log('Server mode is still under development.')
-        return optForHelp
-        // if( args[3] === '-c' && args[4] ) {
-        //     const configPath = processUserPath(args[4])
-        //     const config = JSON.parse( fs.readFileSync(configPath) )
-        //     config.teiDocuments = {
-        //         'fr640_3r-3v-example': processUserPath('./data/fr640_3r-3v-example.xml')
-        //     }
-        //     return { mode, ...config }
-        // } 
+    } else if( mode === 'iiif' ) {
+        if( args.length < 4 ) return optForHelp
+        let config = {
+            mode: mode,
+            targetPath: '.',
+        }
+
+        config.iiifURL = args[3]
+        if( args[4] ) config.targetPath = processUserPath(args[4])
+
+        return config
     }
 
     return optForHelp
@@ -96,7 +96,7 @@ function processArguments() {
 function displayHelp() {
     console.log(`Usage: editioncrafter <command> [-c config_path]|[<tei_path> <output_path> <base_url>]` );
     console.log("Edition Crafter responds to the following <command>s:")
-    console.log("\tserver: Run as a server, requires config_path.")
+    console.log("\tiiif: Process the IIIF Manifest into a TEIDocument.")
     console.log("\tprocess: Process the TEI Document into a manifest, partials, and annotations.")
     console.log("\thelp: Displays this help. ");
 }


### PR DESCRIPTION
### In this PR
- Adds the `iiif` command that takes in a manifest URL and produces a template TEI document at a specified path.
- Updates the README to include documentation about the different available commands, including `iiif`.