### PR TITLE
Remove thumbnail generation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The following commands are available to the EditionCrafter CLI. Note that you ma
     "inputPath": "myfile.xml",
     "outputPath": ".",
     "baseUrl": "http://localhost:8080",
-    "thumbnailWidth": 124,
-    "thumbnailHeight": 192
 }
 ```
 

--- a/data/config.json.example
+++ b/data/config.json.example
@@ -6,6 +6,4 @@
     "inputPath": "",
     "outputPath": "",
     "baseUrl": "http://localhost:8080",
-    "thumbnailWidth": 124,
-    "thumbnailHeight": 192
 }

--- a/src/index.js
+++ b/src/index.js
@@ -93,9 +93,6 @@ function processArguments() {
   let options = parseOptions(args)
 
   if (options.mode === 'process') {
-    options.thumbnailHeight = 192
-    options.thumbnailWidth = 124
-
     if (!options.outputPath) {
       options.outputPath = '.'
     }

--- a/src/render.js
+++ b/src/render.js
@@ -144,7 +144,7 @@ function renderTextAnnotationPage(baseURI, canvasID, surface, apIndex) {
 }
 
 // Builds a painting annotation for the `items` array
-function buildItemAnnotation(canvas, surface, thumbnailWidth, thumbnailHeight) {
+function buildItemAnnotation(canvas, surface) {
   const annotation = structuredClone(annotationTemplate)
   const { imageURL, width, height } = surface
 
@@ -161,12 +161,6 @@ function buildItemAnnotation(canvas, surface, thumbnailWidth, thumbnailHeight) {
   if (surface.mimeType === 'application/json') {
     annotation.body.service = [{
       id: imageURL,
-      type: 'ImageService2',
-      profile: 'http://iiif.io/api/image/2/level2.json',
-    }]
-    annotation.body.thumbnail = [{
-      id: `${imageURL}/full/${thumbnailWidth},${thumbnailHeight}/0/default.jpg`,
-      format: 'image/jpeg',
       type: 'ImageService2',
       profile: 'http://iiif.io/api/image/2/level2.json',
     }]
@@ -219,7 +213,7 @@ function buildTagAnnotations(surface) {
   })
 }
 
-function renderManifest(manifestLabel, baseURI, surfaces, thumbnailWidth, thumbnailHeight, glossaryURL) {
+function renderManifest(manifestLabel, baseURI, surfaces, glossaryURL) {
   const manifest = structuredClone(manifestTemplate)
   manifest.id = `${baseURI}/iiif/manifest.json`
   manifest.label = { en: [manifestLabel] }
@@ -234,7 +228,7 @@ function renderManifest(manifestLabel, baseURI, surfaces, thumbnailWidth, thumbn
     canvas.label = { none: [label] }
     canvas.items[0].id = `${canvas.id}/annotationpage/0`
 
-    const itemAnnotation = buildItemAnnotation(canvas, surface, thumbnailWidth, thumbnailHeight)
+    const itemAnnotation = buildItemAnnotation(canvas, surface)
 
     canvas.items[0].items.push(itemAnnotation)
 
@@ -343,7 +337,7 @@ function renderResources(doc, htmlDoc) {
 }
 
 function renderTEIDocument(xml, options) {
-  const { baseUrl, teiDocumentID, thumbnailWidth, thumbnailHeight } = options
+  const { baseUrl, teiDocumentID } = options
   const doc = new JSDOM(xml, { contentType: 'text/xml' }).window.document
   const status = validateTEIDoc(doc)
   if (status !== 'ok')
@@ -363,7 +357,7 @@ function renderTEIDocument(xml, options) {
   const documentURL = `${baseUrl}${baseUrl !== '/' ? '/' : ''}${teiDocumentID}`
   // TODO temporary hardcode
   const glossaryURL = 'https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json'
-  const manifest = renderManifest(teiDocumentID, documentURL, surfaces, thumbnailWidth, thumbnailHeight, glossaryURL)
+  const manifest = renderManifest(teiDocumentID, documentURL, surfaces, glossaryURL)
 
   return {
     id: teiDocumentID,

--- a/src/store.js
+++ b/src/store.js
@@ -35,8 +35,8 @@ async function loadTEIDocument(teiDocumentID, documentStore) {
     const { archivEngineURL, authToken, projectID } = documentStore
     const { resourceID } = teiDocument
     const { resourceEntries } = await getResources(archivEngineURL, authToken, projectID, resourceID)
-    const { baseUrl, thumbnailWidth, thumbnailHeight } = documentStore
-    const renderOptions = { teiDocumentID, baseUrl, thumbnailWidth, thumbnailHeight }
+    const { baseUrl } = documentStore
+    const renderOptions = { teiDocumentID, baseUrl }
     teiDocument = processResources(resourceEntries, resourceID, renderOptions)
     teiDocuments[teiDocumentID] = teiDocument
     return teiDocument


### PR DESCRIPTION
# Summary

As per the discussion around https://github.com/cu-mkp/editioncrafter/issues/148, we're removing everything thumbnail-related from the CLI app. The frontend component already generates its own thumbnails and the ones generated by the CLI app had hardcoded dimensions that would have made them display incorrectly anyway.