### PR TITLE
TEI validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,7 @@ function processTEIDocument(options) {
   const xml = readFileSync(inputPath, 'utf8')
 
   const teiDoc = renderTEIDocument(xml, options)
-  if (teiDoc.error) {
-    console.log(teiDoc.error)
-  }
-  else {
-    serializeTEIDocument(teiDoc, outputPath)
-  }
+  serializeTEIDocument(teiDoc, outputPath)
 }
 
 async function run(options) {


### PR DESCRIPTION
# Summary

- add a set of rules to the formerly empty `validateTEIDoc` function:
  - require exactly one `facsimile` element
  - require at least one `text` and/or `sourceDoc` element
  - if a `text` element exists, it must contain a `body` which then must contain at least one `div` as a direct child
- refactor the `renderTEIDocument` function to log validation errors to the console and then exit with status code 1, rather than allowing the script to continue with a misleading "EditionCrafter finished" message