### PR TITLE
Context-specific help text

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1,4 +1,4 @@
-# EditionCrafter Help
+# EditionCrafter
 
 Usage: editioncrafter \<command\> [parameters]
 

--- a/docs.md
+++ b/docs.md
@@ -8,7 +8,7 @@ EditionCrafter responds to the following commands:
 
 ### `iiif`
 
-Process the IIIF Manifest into a TEIDocument.
+Process the IIIF Manifest into a TEI Document.
 
 Usage: `editioncrafter iiif [-i iiif_url] [-o output_path]`
 
@@ -22,7 +22,7 @@ Usage: `editioncrafter iiif [-i iiif_url] [-o output_path]`
 
 ### `images`
 
-Process a list of images from a CSV file into a TEIDocument.
+Process a list of images from a CSV file into a TEI Document.
 
 Usage: `editioncrafter images [-i csv_path] [-o output_file]`
 
@@ -36,7 +36,7 @@ Optional parameters:
 
 ### `process`
 
-Process the TEI Document into a manifest, partials, and annotations.
+Process the TEI Document into a manifest, partials, and annotations. These can then be used by the EditionCrafter viewer.
 
 Usage: `editioncrafter process [-i tei_file] [-o output_path]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,6 +244,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",

--- a/src/help.js
+++ b/src/help.js
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { marked } from 'marked'
+import { markedTerminal } from 'marked-terminal'
+import { version } from '../version.js'
+
+marked.use(markedTerminal())
+
+function getHelpText() {
+  const pathName = fileURLToPath(join(import.meta.url, '..', '..', 'docs.md'))
+
+  const contents = readFileSync(pathName)
+    .toString()
+    .replace('# EditionCrafter', `# EditionCrafter ${version}`)
+
+  return marked.parse(contents)
+}
+
+export function displayFullHelp() {
+  const text = getHelpText()
+  console.log(text)
+}
+
+export function displayTargetedHelp(command, param) {
+  const text = getHelpText()
+
+  console.log(text)
+}

--- a/src/help.js
+++ b/src/help.js
@@ -14,16 +14,29 @@ function getHelpText() {
     .toString()
     .replace('# EditionCrafter', `# EditionCrafter ${version}`)
 
-  return marked.parse(contents)
+  return contents
 }
 
 export function displayFullHelp() {
   const text = getHelpText()
-  console.log(text)
+  const parsed = marked.parse(text)
+  console.log(parsed)
 }
 
-export function displayTargetedHelp(command, param) {
+export function displayTargetedHelp(command, params) {
   const text = getHelpText()
 
-  console.log(text)
+  const split = text.split('\n### ')
+
+  const commandSection = split.find(section => section.startsWith(`\`${command}\``))
+
+  if (!commandSection) {
+    return console.log(marked.parse(text))
+  }
+
+  // Log top notice in cyan to be more noticeable.
+  console.log(`\x1B[36mMissing required parameters: ${params.join(', ')}\n`)
+
+  // Reset to normal colors for the help text
+  console.log(`\x1B[0m### ${marked.parse(commandSection)}`)
 }

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,72 @@
+import { exit } from 'node:process'
+import { displayTargetedHelp } from './help.js'
+
+const optionInfo = [
+  {
+    abbrev: '-c',
+    long: '--config',
+    key: 'configPath',
+  },
+  {
+    abbrev: '-t',
+    long: '--text',
+    key: 'textPath',
+  },
+  {
+    abbrev: '-c',
+    long: '--config',
+    key: 'configPath',
+  },
+  {
+    abbrev: '-o',
+    long: '--ouput',
+    key: 'outputPath',
+  },
+  {
+    abbrev: '-i',
+    long: '--input',
+    key: 'inputPath',
+  },
+  {
+    abbrev: '-u',
+    long: '--base-url',
+    key: 'baseUrl',
+  },
+]
+
+export function parseOptions(args, requiredArgs) {
+  const options = {
+    configPath: null,
+    textPath: null,
+    outputPath: null,
+    inputPath: null,
+    baseUrl: null,
+  }
+
+  const mode = args[2]
+
+  // skip the first three args
+  // (Node, EC itself, and the name of the script)
+  for (let i = 3; i < args.length - 1; i = i + 2) {
+    const value = args[i + 1]
+
+    const match = optionInfo.find(opt => opt.abbrev === value || opt.long === value)
+
+    if (!match) {
+      console.error(`Unknown option: ${value}`)
+    }
+
+    options[match.key] = value
+  }
+
+  const missingArgs = requiredArgs
+    ? requiredArgs.filter(name => !options[name])
+    : []
+
+  if (missingArgs.length > 0) {
+    displayTargetedHelp(mode, missingArgs)
+    exit(1)
+  }
+
+  return options
+}

--- a/src/options.js
+++ b/src/options.js
@@ -53,11 +53,11 @@ export function parseOptions(args, requiredArgs) {
 
     const match = optionInfo.find(opt => opt.abbrev === argName || opt.long === argName)
 
-    if (!match) {
-      console.error(`Unknown option: ${argName}`)
+    if (match) {
+      options[match.key] = value
     }
     else {
-      options[match.key] = value
+      console.error(`Unknown option: ${argName}`)
     }
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -48,20 +48,32 @@ export function parseOptions(args, requiredArgs) {
   // skip the first three args
   // (Node, EC itself, and the name of the script)
   for (let i = 3; i < args.length - 1; i = i + 2) {
+    const argName = args[i]
     const value = args[i + 1]
 
-    const match = optionInfo.find(opt => opt.abbrev === value || opt.long === value)
+    const match = optionInfo.find(opt => opt.abbrev === argName || opt.long === argName)
 
     if (!match) {
-      console.error(`Unknown option: ${value}`)
+      console.error(`Unknown option: ${argName}`)
     }
-
-    options[match.key] = value
+    else {
+      options[match.key] = value
+    }
   }
 
-  const missingArgs = requiredArgs
-    ? requiredArgs.filter(name => !options[name])
-    : []
+  const missingArgs = []
+
+  if (requiredArgs) {
+    requiredArgs.forEach((arg) => {
+      if (!options[arg]) {
+        const match = optionInfo.find(opt => opt.key === arg)
+
+        if (match) {
+          missingArgs.push(match.abbrev)
+        }
+      }
+    })
+  }
 
   if (missingArgs.length > 0) {
     displayTargetedHelp(mode, missingArgs)


### PR DESCRIPTION
# Summary

- adds the version number back into the help text (somehow I missed that in #42)
- refactors the way options are parsed to require less boilerplate in `processArguments` when checking for required arguments
- moves help-related code to `help.js`, with a new `displayTargetedHelp` function that displays just the section for a given command and a list of missing parameters

## Example

In the terminal, the top line is colored to make it stand out more.

```
$ ./editioncrafter.js images -i ./images-example.csv
Missing required parameters: -o

### images

Process a list of images from a CSV file into a TEIDocument.

Usage: editioncrafter images [-i csv_path] [-o output_file]

Required parameters:

    * -i csv_path
    * -o output_file

Optional parameters:

    * -t text_file_folder
    * -c: Config file
```