### PR TITLE
Add checks for `process` XML input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3028,18 +3028,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
-    "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { basename, resolve } from 'node:path'
 import { argv, cwd, exit } from 'node:process'
 
@@ -16,6 +16,12 @@ function processUserPath(input_path) {
 
 function processTEIDocument(options) {
   const { inputPath, outputPath } = options
+
+  if (!existsSync(inputPath)) {
+    console.error(`File not found: ${inputPath}`)
+    exit(1)
+  }
+
   const xml = readFileSync(inputPath, 'utf8')
 
   const teiDoc = renderTEIDocument(xml, options)
@@ -56,6 +62,11 @@ function processArguments() {
 
   if (mode === 'process') {
     let options = parseOptions(args, ['inputPath'])
+
+    if (!options.inputPath.endsWith('.xml')) {
+      console.error('Error: Input must be an XML document.')
+      exit(1)
+    }
 
     if (!options.outputPath) {
       options.outputPath = '.'

--- a/src/options.js
+++ b/src/options.js
@@ -80,5 +80,7 @@ export function parseOptions(args, requiredArgs) {
     exit(1)
   }
 
+  options.mode = mode
+
   return options
 }


### PR DESCRIPTION
# Summary

This PR expands the error checking for the `process` script:

- adds a check for whether the input file has a `.xml` file extension
- adds a check for whether the input file exists