### PR TITLE
Updates to `db.js` for tag explorer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,12 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Test Process",
+      "name": "Test DB",
       "skipFiles": [
         "<node_internals>/**"
       ],
       "program": "${workspaceFolder}/editioncrafter",
-      "args": ["process", "-i", "data/bb-ms.xml", "-o", "public"]
+      "args": ["database", "-i", "data/odt/caryatidum_tagged.xml", "data/odt/grotisch_fur_alle_kunstler_tagged.xml", "-o", "public/odt.sqlite"]
     },
     {
       "type": "node",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # editioncrafter-cli
+[![DOI](https://zenodo.org/badge/607722189.svg)](https://doi.org/10.5281/zenodo.16755974)
 
 This is the command line tool to take a TEI XML file and turn it into a IIIF Manifest and the necessary Web Annotations to display the text in EditionCrafter.
 

--- a/data/odt/caryatidum_tagged.xml
+++ b/data/odt/caryatidum_tagged.xml
@@ -2,7 +2,7 @@
 	<teiHeader xml:id="header">
 		<fileDesc>
 			<titleStmt>
-				<title>series_002_caryatidum</title>
+				<title>Caryatidum</title>
 			</titleStmt>
 			<publicationStmt>
 				<p/>

--- a/data/odt/grotisch_fur_alle_kunstler_tagged.xml
+++ b/data/odt/grotisch_fur_alle_kunstler_tagged.xml
@@ -2,7 +2,7 @@
 	<teiHeader xml:id="header">
 		<fileDesc>
 			<titleStmt>
-				<title>series_004_grotisch_fur_alle_kunstler</title>
+				<title>Grotisch Fur Alle Kunstler</title>
 			</titleStmt>
 			<publicationStmt>
 				<p/>

--- a/data/odt/mansches_de_coutiaus_tagged.xml
+++ b/data/odt/mansches_de_coutiaus_tagged.xml
@@ -2,7 +2,7 @@
 	<teiHeader xml:id="header">
 		<fileDesc>
 			<titleStmt>
-				<title>series_007_mansches_de_coutiaus</title>
+				<title>Mansches de Coutiaus</title>
 			</titleStmt>
 			<publicationStmt>
 				<p/>

--- a/data/odt/passio_verbigenae_tagged.xml
+++ b/data/odt/passio_verbigenae_tagged.xml
@@ -2,7 +2,7 @@
 	<teiHeader xml:id="header">
 		<fileDesc>
 			<titleStmt>
-				<title>series_001_passio_verbigenae</title>
+				<title>Passio Verbigenae</title>
 			</titleStmt>
 			<publicationStmt>
 				<p/>

--- a/docs.md
+++ b/docs.md
@@ -36,12 +36,12 @@ Optional parameters:
 
 ### `process`
 
-Process the TEI Document into a manifest, partials, and annotations. These can then be used by the EditionCrafter viewer.
+Process the TEI Document(s) into a manifest, partials, and annotations. These can then be used by the EditionCrafter viewer. Requires EITHER an input file or an input folder.
 
-Usage: `editioncrafter process [-i tei_file] [-o output_path]`
+Usage: `editioncrafter process [-i tei_file] [-o output_path]` OR `editioncrafter process [-f tei_folder] [-o output_path]`
 
 Required parameters:
-* -i tei_file
+* -i tei_file OR -f tei_folder
 * -o output_path
 
 Optional parameters:
@@ -52,18 +52,14 @@ Optional parameters:
 
 Process one or more TEI documents into a SQLite file containing a directory of categories and tags. This can be used with the Record List component from the EditionCrafter viewer package, or it can be browsed directly with a SQLite viewer.
 
-Usage: `editioncrafter database [-i tei_file(s)] [-o output_path]`
+Usage: `editioncrafter database [-i tei_file(s)] [-o output_path]` OR `editioncrafter database [-f tei_folder] [-o output_path]`
 
 You can pass as many TEI documents as you want by writing them all after the `-i`. For example:
 
 `editioncrafter database -i data/my_first_doc.xml data/my_second_doc.xml -o output_folder`
 
-If you want to pass an entire folder full of TEI documents to `database`, you can use the `*` wildcard shorthand:
-
-`editioncrafter database -i data/* -o output_folder`
-
 Required parameters:
-* -i tei_file(s)
+* -i tei_file(s) OR -f tei_folder
 * -o output_path (must end in .sqlite)
 
 ### help

--- a/src/db.js
+++ b/src/db.js
@@ -26,6 +26,9 @@ function populateTables(db) {
       id INTEGER PRIMARY KEY,
       xml_id STRING,
       image_url STRING,
+      width INTEGER,
+      height INTEGER,
+      image_type STRING,
       name STRING,
       position INTEGER,
       document_id INTEGER REFERENCES documents(id)
@@ -328,6 +331,8 @@ function parseSurfaces(db, xml, documentId) {
       for (let i = 0; i < surfaces.length; i++) {
         const surface = surfaces[i]
         const xmlId = surface.getAttribute('xml:id')
+        const width = surface.getAttribute('lrx')
+        const height = surface.getAttribute('lry')
 
         const labelEl = surface.querySelector('label')
 
@@ -346,10 +351,12 @@ function parseSurfaces(db, xml, documentId) {
         }
 
         const imageURL = graphicEl.getAttribute('url')
+        const mimeType = graphicEl.getAttribute('mimeType')
+        const imageType = mimeType == "application/json" ? 'iiif' : 'raster'
 
         const surfaceResult = db
-          .prepare('INSERT INTO surfaces (name, xml_id, image_url, document_id, position) VALUES (?, ?, ?, ?, ?)')
-          .run(name, xmlId, imageURL, documentId, i)
+          .prepare('INSERT INTO surfaces (name, xml_id, image_url, width, height, image_type, document_id, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+          .run(name, xmlId, imageURL, width, height, imageType, documentId, i)
 
         parseZones(db, surface, layerResult.lastInsertRowid, surfaceResult.lastInsertRowid)
       }

--- a/src/db.js
+++ b/src/db.js
@@ -25,6 +25,7 @@ function populateTables(db) {
     CREATE TABLE surfaces (
       id INTEGER PRIMARY KEY,
       xml_id STRING,
+      image_url STRING,
       name STRING,
       position INTEGER,
       document_id INTEGER REFERENCES documents(id)
@@ -337,9 +338,18 @@ function parseSurfaces(db, xml, documentId) {
 
         const name = labelEl.textContent
 
+        const graphicEl = surface.querySelector('graphic')
+
+        if (!graphicEl) {
+          console.error(`Surface ${xmlId} does not have a image URL (a <graphic> element with url attribute) and will be skipped.`)
+          continue
+        }
+
+        const imageURL = graphicEl.getAttribute('url')
+
         const surfaceResult = db
-          .prepare('INSERT INTO surfaces (name, xml_id, document_id, position) VALUES (?, ?, ?, ?)')
-          .run(name, xmlId, documentId, i)
+          .prepare('INSERT INTO surfaces (name, xml_id, image_url, document_id, position) VALUES (?, ?, ?, ?, ?)')
+          .run(name, xmlId, imageURL, documentId, i)
 
         parseZones(db, surface, layerResult.lastInsertRowid, surfaceResult.lastInsertRowid)
       }

--- a/src/db.js
+++ b/src/db.js
@@ -10,8 +10,8 @@ import jsdom from 'jsdom'
 // we should refactor this to move away from the
 // third-party better-sqlite3 package.
 import Database from 'better-sqlite3'
-import { scrubTree } from './render.js'
 import { getPathBasename } from './parse-path.js'
+import { scrubTree } from './render.js'
 
 const { JSDOM } = jsdom
 
@@ -41,13 +41,20 @@ function populateTables(db) {
     CREATE TABLE taxonomies (
       id INTEGER PRIMARY KEY,
       name STRING,
-      xml_id STRING
+      xml_id STRING UNIQUE,
+      is_surface BOOLEAN
+    );
+    CREATE TABLE document_taggings (
+      id INTEGER PRIMARY KEY,
+      document INTEGER REFERENCES documents(id),
+      tag INTEGER REFERENCES tags(id)
     );
     CREATE TABLE tags (
       id INTEGER PRIMARY KEY,
       name STRING,
       xml_id STRING,
-      taxonomy_id INTEGER REFERENCES taxonomies(id)
+      taxonomy_id INTEGER REFERENCES taxonomies(id),
+      UNIQUE(xml_id, taxonomy_id)
     );
     CREATE TABLE elements (
       id INTEGER PRIMARY KEY,
@@ -77,6 +84,17 @@ async function createDatabase(options) {
 
   populateTables(db)
 
+  // author, publisher, languages, and locations are encoded in the TEI differently from other categories, so let's
+  // just add those rows to the taxonomies table now
+
+  const seedTaxonomies = db.prepare('INSERT INTO taxonomies (name, xml_id) VALUES (?,?)')
+
+  // for the current use case in ODT we're excluding the author field; ideally this should be configurable?
+  // seedTaxonomies.run('Author', 'author')
+  seedTaxonomies.run('Publisher', 'publisher')
+  seedTaxonomies.run('Languages', 'languages')
+  seedTaxonomies.run('Locations', 'locations')
+
   for await (const path of options.inputPath) {
     await parseXml(db, path)
   }
@@ -86,7 +104,6 @@ async function createDatabase(options) {
 
 async function parseXml(db, path) {
   const xmlFile = fs.readFileSync(path).toString()
-
   const xml = new JSDOM(xmlFile, { contentType: 'text/xml' }).window.document
   const localID = getPathBasename(path)
 
@@ -105,11 +122,13 @@ async function parseXml(db, path) {
 
     const name = biblEl.textContent
 
-    const { lastInsertRowid } = db
-      .prepare(`INSERT INTO taxonomies (name, xml_id) VALUES (?, ?)`)
+    db
+      .prepare(`INSERT INTO taxonomies (name, xml_id, is_surface) VALUES (?, ?, true) ON CONFLICT DO NOTHING`)
       .run(name, xmlId)
 
-    parseTaxonomy(db, tax, lastInsertRowid)
+    const { id } = db.prepare('SELECT id FROM taxonomies WHERE xml_id = ?').get(xmlId)
+
+    parseTaxonomy(db, tax, id)
   }
 
   parseSurfaces(db, xml, documentId)
@@ -129,7 +148,97 @@ function parseDocument(db, localID, xml) {
 
   const { lastInsertRowid } = db
     .prepare('INSERT INTO documents (name, local_id) VALUES (?,?)')
-    .run(name,localID)
+    .run(name, localID)
+
+  // prepare some common db statements
+
+  const getTag = db.prepare('SELECT id FROM tags WHERE xml_id = ? AND taxonomy_id = ?')
+  const getTax = db.prepare('SELECT id FROM taxonomies WHERE xml_id = ?')
+  const insertDocTag = db.prepare('INSERT INTO document_taggings (document, tag) VALUES (?,?)')
+  const insertTag = db.prepare('INSERT INTO tags (name, xml_id, taxonomy_id) VALUES (?,?,?) ON CONFLICT DO NOTHING')
+  const insertTax = db.prepare('INSERT INTO taxonomies (name, xml_id) VALUES (?,?) ON CONFLICT DO NOTHING')
+
+  // get document languages
+  const languages = xml.querySelectorAll('teiHeader > profileDesc > langUsage > language')
+  if (languages && languages.length) {
+    for (const lang of languages) {
+      const code = lang.getAttribute('ident')
+      const languageTax = getTax.get('languages')
+      insertTag.run(lang.textContent, code, languageTax.id)
+      const { id } = getTag.get(code, languageTax.id)
+      insertDocTag.run(lastInsertRowid, id)
+    }
+  }
+
+  // get document agents
+  const agents = xml.querySelectorAll('teiHeader > fileDesc > titleStmt > respStmt')
+  if (agents && agents.length) {
+    for (const agent of agents) {
+      const role = agent.querySelector('resp')
+      const person = agent.querySelector('name')
+
+      if (!role) {
+        console.error(`Document ${localID} has an agent with no defined role. Please add a role for all agents.`)
+        continue
+      }
+      if (!person) {
+        console.error(`Document ${localID} has an agent with no defined name. Please add a name for all agents.`)
+        continue
+      }
+
+      insertTax.run(role.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), role.getAttribute('sameAs'))
+      const roleRow = getTax.get(role.getAttribute('sameAs'))
+      insertTag.run(person.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), person.getAttribute('sameAs'), roleRow.id)
+
+      const agentId = getTag.get(person.getAttribute('sameAs'), roleRow.id)
+
+      insertDocTag.run(lastInsertRowid, agentId.id)
+    }
+  }
+  // deal with authors
+  // const authors = xml.querySelectorAll('teiHeader > fileDesc > titleStmt > author')
+  // if (authors && authors.length) {
+  //   const { id } = getTax.get('author')
+  //   for (const auth of authors) {
+  //     insertTag.run(auth.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), auth.getAttribute('sameAs'), id)
+  //     const agentId = getTag.get(auth.getAttribute('sameAs'), id)
+  //     insertDocTag.run(lastInsertRowid, agentId.id)
+  //   }
+  // }
+
+  // deal with publishers
+  const publishers = xml.querySelectorAll('teiHeader > fileDesc > publicationStmt > publisher')
+  if (publishers && publishers.length) {
+    const { id } = getTax.get('publisher')
+    for (const pub of publishers) {
+      insertTag.run(pub.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), pub.getAttribute('sameAs'), id)
+      const agentId = getTag.get(pub.getAttribute('sameAs'), id)
+      insertDocTag.run(lastInsertRowid, agentId.id)
+    }
+  }
+
+  // deal with cities
+  const locations = xml.querySelectorAll('teiHeader > fileDesc > publicationStmt > pubPlace')
+  if (locations && locations.length) {
+    const { id } = getTax.get('locations')
+    for (const loc of locations) {
+      insertTag.run(loc.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), loc.getAttribute('sameAs'), id)
+      const locId = getTag.get(loc.getAttribute('sameAs'), id)
+      insertDocTag.run(lastInsertRowid, locId.id)
+    }
+  }
+
+  // deal with keywords
+  const keywords = xml.querySelectorAll('teiHeader > profileDesc > textClass > keywords > term')
+  if (keywords && keywords.length) {
+    for (const term of keywords) {
+      insertTax.run(term.getAttribute('type'), term.getAttribute('type'))
+      const { id } = getTax.get(term.getAttribute('type'))
+      insertTag.run(term.textContent.replaceAll('\n', ' ').replaceAll('\t', ''), term.getAttribute('sameAs'), id)
+      const tagId = getTag.get(term.getAttribute('sameAs'), id)
+      insertDocTag.run(lastInsertRowid, tagId.id)
+    }
+  }
 
   return lastInsertRowid
 }
@@ -149,7 +258,7 @@ function parseTaxonomy(db, el, taxonomyId) {
     const name = desc.textContent
 
     db
-      .prepare('INSERT INTO tags (name, xml_id, taxonomy_id) VALUES (?, ?, ?)')
+      .prepare('INSERT INTO tags (name, xml_id, taxonomy_id) VALUES (?, ?, ?) ON CONFLICT DO NOTHING')
       .run(name, xmlId, taxonomyId)
 
     const childCategories = cat.querySelectorAll(':scope > category')
@@ -352,7 +461,7 @@ function parseSurfaces(db, xml, documentId) {
 
         const imageURL = graphicEl.getAttribute('url')
         const mimeType = graphicEl.getAttribute('mimeType')
-        const imageType = mimeType == "application/json" ? 'iiif' : 'raster'
+        const imageType = mimeType === 'application/json' ? 'iiif' : 'raster'
 
         const surfaceResult = db
           .prepare('INSERT INTO surfaces (name, xml_id, image_url, width, height, image_type, document_id, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')

--- a/src/db.js
+++ b/src/db.js
@@ -369,24 +369,26 @@ function ingestTaggedElement(db, el, type, layerId, surfaceId, parentId) {
   const tagXmlIds = el
     .getAttribute('ana')
     .split(' ')
-    // remove the # before each ID
-    .map(str => str.slice(1))
+    // remove the # before each ID, if present
+    .map(str => str?.replace('#', ''))
 
   for (const tagXmlId of tagXmlIds) {
-    const tagLookup = db
-      .prepare('SELECT id FROM tags WHERE tags.xml_id = ?')
-      .get(tagXmlId)
+    if (tagXmlId && tagXmlId.length) {
+      const tagLookup = db
+        .prepare('SELECT id FROM tags WHERE tags.xml_id = ?')
+        .get(tagXmlId)
 
-    const tagDbId = tagLookup?.id
+      const tagDbId = tagLookup?.id
 
-    if (!tagDbId) {
-      console.log(`Tag #${tagXmlId} not found in taxonomy element.`)
-      continue
+      if (!tagDbId) {
+        console.log(`Tag #${tagXmlId} not found in taxonomy element.`)
+        continue
+      }
+
+      db
+        .prepare('INSERT INTO taggings (element_id, tag_id) VALUES (?, ?)')
+        .run(elementDbId, tagDbId)
     }
-
-    db
-      .prepare('INSERT INTO taggings (element_id, tag_id) VALUES (?, ?)')
-      .run(elementDbId, tagDbId)
   }
 
   return elementDbId

--- a/src/db.js
+++ b/src/db.js
@@ -79,6 +79,12 @@ async function createDatabase(options) {
 
   const db = new Database(options.outputPath)
 
+  // if we were passed a folder, get a list of the files; otherwise we'll just iterate over the provided paths
+  let allFiles = options.inputPath
+  if (options.inputFolder) {
+    allFiles = fs.readdirSync(options.inputFolder).filter(f => (f.toLowerCase().endsWith('.xml'))).map(f => (`${options.inputFolder}/${f}`))
+  }
+
   // the better-sqlite3 docs suggest this line for better performance
   db.pragma('journal_mode = WAL')
 
@@ -95,17 +101,23 @@ async function createDatabase(options) {
   seedTaxonomies.run('Languages', 'languages')
   seedTaxonomies.run('Locations', 'locations')
 
-  for await (const path of options.inputPath) {
-    await parseXml(db, path)
+  for await (const path of allFiles) {
+    try {
+      await parseXml(db, path)
+    }
+    catch (error) {
+      console.error(`Error processing ${getPathBasename(path)}: ${error}`)
+    }
   }
 
   process.on('exit', () => db.close())
 }
 
 async function parseXml(db, path) {
+  const localID = getPathBasename(path)
+  console.log(`Processing file ${localID}...`)
   const xmlFile = fs.readFileSync(path).toString()
   const xml = new JSDOM(xmlFile, { contentType: 'text/xml' }).window.document
-  const localID = getPathBasename(path)
 
   const taxonomies = xml.querySelectorAll('taxonomy')
 
@@ -130,7 +142,6 @@ async function parseXml(db, path) {
 
     parseTaxonomy(db, tax, id)
   }
-
   parseSurfaces(db, xml, documentId)
   parseLayers(db, xml, documentId)
 }
@@ -244,11 +255,18 @@ function parseDocument(db, localID, xml) {
 }
 
 function parseTaxonomy(db, el, taxonomyId) {
-  const categories = el.querySelectorAll(':scope > category')
+  // for nested taxonomies, we're only going to take the leaves for now
+  const categories = el.querySelectorAll('category')
 
   for (const cat of categories) {
+    const childCategories = cat.querySelectorAll(':scope > category')
     const xmlId = cat.getAttribute('xml:id')
     const desc = cat.querySelector('catDesc')
+
+    // if this category has children, skip it
+    if (childCategories.length) {
+      continue
+    }
 
     if (!desc) {
       console.error(`Category ${xmlId} does not have a name (which should be contained in a <catDesc> element) and will be skipped.`)
@@ -260,12 +278,6 @@ function parseTaxonomy(db, el, taxonomyId) {
     db
       .prepare('INSERT INTO tags (name, xml_id, taxonomy_id) VALUES (?, ?, ?) ON CONFLICT DO NOTHING')
       .run(name, xmlId, taxonomyId)
-
-    const childCategories = cat.querySelectorAll(':scope > category')
-
-    if (childCategories.length > 0) {
-      console.warn(`Nested category found under ${name}. EditionCrafter does not support nested categories, so this will be skipped.`)
-    }
   }
 }
 

--- a/src/iiif.js
+++ b/src/iiif.js
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs'
+import { readdirSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 import axios from 'axios'
 import { getFacsString } from './lib/images.js'
@@ -303,7 +303,13 @@ async function processIIIF(options) {
     const teiString = facsTemplate(data, options.textPath)
     writeFileSync(options.outputPath, teiString)
   }
-  await importPresentationEndpoint(options.inputPath, onSuccess)
+  // if we were passed a folder, get the files from it
+  let allFiles = options.inputPath
+  if (options.inputFolder) {
+    allFiles = readdirSync(options.inputFolder)
+  }
+  console.log(allFiles)
+  await importPresentationEndpoint(allFiles, onSuccess)
 };
 
 // VARIOUS HELPER FUNCTIONS

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, resolve } from 'node:path'
 import { argv, cwd, exit } from 'node:process'
 
@@ -16,17 +16,35 @@ function processUserPath(input_path) {
 }
 
 function processTEIDocument(options) {
-  const { inputPath, outputPath } = options
+  const { inputPath, outputPath, inputFolder } = options
 
-  if (!existsSync(inputPath)) {
+  if (inputPath && !existsSync(inputPath)) {
     console.error(`File not found: ${inputPath}`)
     exit(1)
   }
 
-  const xml = readFileSync(inputPath, 'utf8')
+  if (inputFolder && !existsSync(inputFolder)) {
+    console.error(`Folder not found: ${inputFolder}`)
+    exit(1)
+  }
 
-  const teiDoc = renderTEIDocument(xml, options)
-  serializeTEIDocument(teiDoc, outputPath)
+  if (inputFolder) {
+    const files = readdirSync(inputFolder)
+    for (const file of files) {
+      if (file.toLowerCase().endsWith('.xml')) {
+        const path = `${inputFolder}/${file}`
+        const xml = readFileSync(path, 'utf8')
+        const teiDoc = renderTEIDocument(xml, { ...options, teiDocumentID: getResourceIDFromPath(path) })
+        serializeTEIDocument(teiDoc, outputPath)
+      }
+    }
+  }
+  else {
+    const xml = readFileSync(inputPath, 'utf8')
+
+    const teiDoc = renderTEIDocument(xml, options)
+    serializeTEIDocument(teiDoc, outputPath)
+  }
 }
 
 async function run(options) {
@@ -65,14 +83,19 @@ function processArguments() {
   const mode = args[2]
 
   if (mode === 'process') {
-    let options = parseOptions(args, ['inputPath'])
+    let options = parseOptions(args)
 
-    if (Array.isArray(options.inputPath)) {
+    if (!options.inputPath && !options.inputFolder) {
+      console.error('Error: You must provide either an input file or folder.')
+      exit(1)
+    }
+
+    if (options.inputPath && Array.isArray(options.inputPath)) {
       console.error('Error: The process command only accepts one input path.')
       exit(1)
     }
 
-    if (!options.inputPath.endsWith('.xml')) {
+    if (options.inputPath && !options.inputPath.endsWith('.xml')) {
       console.error('Error: Input must be an XML document.')
       exit(1)
     }
@@ -99,10 +122,16 @@ function processArguments() {
     }
 
     // parse command line params
-    options.inputPath = processUserPath(options.inputPath)
+    if (options.inputPath) {
+      options.inputPath = processUserPath(options.inputPath)
+    }
     options.outputPath = processUserPath(options.outputPath)
-
-    options.teiDocumentID = getResourceIDFromPath(options.inputPath)
+    if (options.inputFolder) {
+      options.inputFolder = processUserPath(options.inputFolder)
+    }
+    if (options.inputPath) {
+      options.teiDocumentID = getResourceIDFromPath(options.inputPath)
+    }
     return options
   }
   else if (mode === 'iiif') {
@@ -128,18 +157,28 @@ function processArguments() {
     return options
   }
   else if (mode === 'database') {
-    const options = parseOptions(args, ['inputPath', 'outputPath'])
+    const options = parseOptions(args, ['outputPath'])
 
-    if (typeof options.inputPath === 'string') {
+    if (!options.inputPath && !options.inputFolder) {
+      console.error('Error: You must provide an input filepath or folder.')
+    }
+
+    if (options.inputPath && typeof options.inputPath === 'string') {
       options.inputPath = [options.inputPath]
     }
 
-    options.inputPath.forEach((path) => {
-      if (!existsSync(path)) {
-        console.error(`Input path ${path} doesn\'t exist.`)
-        exit(1)
-      }
-    })
+    if (options.inputFolder && !existsSync(options.inputFolder)) {
+      console.error('Error: Input folder not found.')
+    }
+
+    if (options.inputPath) {
+      options.inputPath.forEach((path) => {
+        if (!existsSync(path)) {
+          console.error(`Input path ${path} doesn\'t exist.`)
+          exit(1)
+        }
+      })
+    }
 
     if (!options.outputPath.endsWith('.sqlite')) {
       console.error('Database path must have a .sqlite file extension.')

--- a/src/options.js
+++ b/src/options.js
@@ -13,11 +13,6 @@ const optionInfo = [
     key: 'textPath',
   },
   {
-    abbrev: '-c',
-    long: '--config',
-    key: 'configPath',
-  },
-  {
     abbrev: '-o',
     long: '--ouput',
     key: 'outputPath',
@@ -27,6 +22,11 @@ const optionInfo = [
     long: '--input',
     key: 'inputPath',
     multiple: true,
+  },
+  {
+    abbrev: '-f',
+    long: '--folder',
+    key: 'inputFolder',
   },
   {
     abbrev: '-u',
@@ -43,6 +43,7 @@ export function parseOptions(args, requiredArgs) {
     textPath: null,
     outputPath: null,
     inputPath: null,
+    inputFolder: null,
     baseUrl: null,
     mode,
   }

--- a/src/parse-path.js
+++ b/src/parse-path.js
@@ -1,0 +1,7 @@
+// Return the name of the resource based on the file path, minus the extension
+export function getPathBasename(path) {
+    const normalized = path.replaceAll('\\','/')
+    const withoutExt = normalized.replace(/\..*$/,'')
+    const lastSlash = withoutExt.lastIndexOf('/')
+    return lastSlash > 0 ? withoutExt.substr(lastSlash+1) : withoutExt
+}

--- a/src/render.js
+++ b/src/render.js
@@ -383,7 +383,7 @@ export function renderTEIDocument(xml, options) {
   const status = validateTEIDoc(doc)
 
   if (status !== 'ok') {
-    console.error(status)
+    console.error(`Error processing ${teiDocumentID}: ${status}`)
     process.exit(1)
   }
 


### PR DESCRIPTION
### In this PR
Adds functionality to the `database` command to deal with document metadata contained in the header, for use with the `TagExplorer` component.

See https://performant-software.github.io/editioncrafter/iframe.html?args=&globals=&id=editioncrafter--tag-explore-example&viewMode=story#/ec for an example using the output of the `database` command to populate the tag explorer.